### PR TITLE
Add missing parsing helpers and async pytest hook

### DIFF
--- a/analyze/metruyenfull_parse.py
+++ b/analyze/metruyenfull_parse.py
@@ -1,0 +1,59 @@
+"""Helpers for scraping the metruyenfull site."""
+from __future__ import annotations
+
+import re
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+
+
+async def get_story_metadata(adapter, story_url):
+    """Fetch and parse story level metadata."""
+
+    response = await make_request(story_url, adapter)  # type: ignore[name-defined]
+    soup = BeautifulSoup(response.text, 'html.parser')
+
+    title_tag = soup.select_one('h1.title, h1[itemprop="name"], .title h1')
+    title = title_tag.get_text(strip=True) if title_tag else ''
+
+    author_tag = soup.select_one('[itemprop="author"]')
+    if author_tag:
+        author = author_tag.get_text(strip=True) or author_tag.get('title', '')
+    else:
+        author = ''
+
+    description_tag = soup.select_one('.desc-text-full, .desc-text, [itemprop="description"]')
+    description = description_tag.get_text(strip=True) if description_tag else ''
+
+    categories = []
+    for anchor in soup.select('[itemprop="genre"][href]'):
+        name = anchor.get_text(strip=True)
+        if not name:
+            continue
+        categories.append({'name': name, 'url': urljoin(story_url, anchor['href'])})
+
+    total_chapters = None
+    chapter_span = soup.select_one('.label-success, .total-chapters')
+    if chapter_span:
+        match = re.search(r'(\d+)', chapter_span.get_text())
+        if match:
+            total_chapters = int(match.group(1))
+
+    if total_chapters is None:
+        try:
+            chapters = await get_chapters_from_story(adapter, story_url)  # type: ignore[name-defined]
+            total_chapters = len(chapters)
+        except Exception:
+            total_chapters = None
+
+    cover_tag = soup.select_one('img[itemprop="image"], .cover img')
+    cover = urljoin(story_url, cover_tag['src']) if cover_tag and cover_tag.get('src') else ''
+
+    return {
+        'title': title,
+        'author': author,
+        'description': description,
+        'categories': categories,
+        'total_chapters_on_site': total_chapters or 0,
+        'cover': cover,
+    }

--- a/analyze/truyenfull_vision_parse.py
+++ b/analyze/truyenfull_vision_parse.py
@@ -1,0 +1,32 @@
+"""Parsing helpers for the Truyenfull Vision site."""
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+
+def get_input_value(soup: BeautifulSoup, element_id: str, default: str | None = None) -> str | None:
+    """Return the value of an ``<input>`` element with ``element_id``.
+
+    Parameters
+    ----------
+    soup:
+        Parsed BeautifulSoup document that contains the input elements.
+    element_id:
+        The ``id`` attribute to search for.
+    default:
+        Value returned when the input cannot be located or does not have
+        a ``value`` attribute.
+    """
+
+    if not soup or not element_id:
+        return default
+
+    element = soup.find('input', id=element_id)
+    if not element:
+        return default
+
+    value = element.get('value')
+    if value is None:
+        return default
+
+    return value

--- a/analyze/vivutruyen_parse.py
+++ b/analyze/vivutruyen_parse.py
@@ -1,0 +1,28 @@
+"""Utilities for parsing Vivutruyen content."""
+from __future__ import annotations
+
+from urllib.parse import urljoin
+
+
+def absolutize(url: str | None, base_url: str | None = None) -> str:
+    """Return an absolute URL for ``url``.
+
+    Parameters
+    ----------
+    url:
+        The input URL or path.  If ``None`` or an empty string is
+        provided an empty string is returned.
+    base_url:
+        Base URL used for resolving relative paths.  When ``None`` the
+        Vivutruyen domain is used.
+    """
+
+    if not url:
+        return ""
+
+    stripped = url.strip()
+    if stripped.startswith(("http://", "https://")):
+        return stripped
+
+    base = (base_url or "https://vivutruyen.com").rstrip("/")
+    return urljoin(base + '/', stripped.lstrip('/'))

--- a/conftest.py
+++ b/conftest.py
@@ -3,30 +3,30 @@ import inspect
 import pytest
 
 
-# def pytest_configure(config: pytest.Config) -> None:
-#     config.addinivalue_line(
-#         "markers",
-#         "asyncio: mark test to run inside an event loop without pytest-asyncio",
-#     )
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "asyncio: mark test to run inside an event loop without pytest-asyncio",
+    )
 
 
-# @pytest.hookimpl(tryfirst=True)
-# def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
-#     if "asyncio" not in pyfuncitem.keywords:
-#         return None
-# 
-#     test_func = pyfuncitem.obj
-#     if not inspect.iscoroutinefunction(test_func):
-#         return None
-# 
-#     sig = inspect.signature(test_func)
-#     call_kwargs = {name: pyfuncitem.funcargs[name] for name in sig.parameters}
-# 
-#     loop = asyncio.new_event_loop()
-#     try:
-#         asyncio.set_event_loop(loop)
-#         loop.run_until_complete(test_func(**call_kwargs))
-#     finally:
-#         asyncio.set_event_loop(None)
-#         loop.close()
-#     return True
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    if "asyncio" not in pyfuncitem.keywords:
+        return None
+
+    test_func = pyfuncitem.obj
+    if not inspect.iscoroutinefunction(test_func):
+        return None
+
+    sig = inspect.signature(test_func)
+    call_kwargs = {name: pyfuncitem.funcargs[name] for name in sig.parameters}
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(test_func(**call_kwargs))
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+    return True


### PR DESCRIPTION
## Summary
- restore the Vivutruyen, Truyenfull Vision, and Metruyenfull parsing helpers used by the tests
- enable async pytest tests to run by providing a lightweight event loop hook

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da03431e0c8329b1b18c2f62fabf3d