### PR TITLE
Handle chunked chapter ranges for XTruyen

### DIFF
--- a/tests/test_xtruyen_parse.py
+++ b/tests/test_xtruyen_parse.py
@@ -4,6 +4,7 @@ from analyze.xtruyen_parse import (
     parse_chapter_content,
     parse_chapter_list,
     parse_genres,
+    parse_story_info,
     parse_story_list,
 )
 
@@ -43,6 +44,17 @@ def test_parse_chapter_list_keeps_natural_order():
     assert chapters, "Expected chapters to be parsed"
     assert chapters[0]["title"].startswith("Chương 1")
     assert chapters[1]["title"].startswith("Chương 2")
+
+
+def test_parse_story_info_detects_chapter_ranges():
+    html = _load_fixture(FIXTURES_DIR / "detail_story.txt")
+    info = parse_story_info(html, "https://xtruyen.vn")
+
+    ranges = info.get("chapter_ranges")
+    assert isinstance(ranges, list) and ranges, "Expected chapter ranges to be captured"
+    assert ranges[0] == {"from": 1, "to": 100}
+    assert ranges[1] == {"from": 101, "to": 200}
+    assert info.get("total_chapters_on_site") == 280
 
 
 def test_parse_chapter_content_decompresses_payload():


### PR DESCRIPTION
## Summary
- parse and expose the collapsible chapter group ranges from the story detail HTML so totals stay accurate when the inline list is empty
- respect the detected ranges when calling the XTruyen AJAX endpoint to avoid redundant chapter requests and keep ordering stable
- extend the parser test suite to cover the new chapter range extraction logic

## Testing
- pytest tests/test_xtruyen_parse.py -q
- pytest tests/test_xtruyen_adapter.py -q *(fails: async plugin not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dba6a8db4c8329b7ed48683f03ebd5