### PR TITLE
Fix async test execution and restore chapter utility compatibility

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,30 +3,30 @@ import inspect
 import pytest
 
 
-# def pytest_configure(config: pytest.Config) -> None:
-#     config.addinivalue_line(
-#         "markers",
-#         "asyncio: mark test to run inside an event loop without pytest-asyncio",
-#     )
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "asyncio: mark test to run inside an event loop without pytest-asyncio",
+    )
 
 
-# @pytest.hookimpl(tryfirst=True)
-# def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
-#     if "asyncio" not in pyfuncitem.keywords:
-#         return None
-# 
-#     test_func = pyfuncitem.obj
-#     if not inspect.iscoroutinefunction(test_func):
-#         return None
-# 
-#     sig = inspect.signature(test_func)
-#     call_kwargs = {name: pyfuncitem.funcargs[name] for name in sig.parameters}
-# 
-#     loop = asyncio.new_event_loop()
-#     try:
-#         asyncio.set_event_loop(loop)
-#         loop.run_until_complete(test_func(**call_kwargs))
-#     finally:
-#         asyncio.set_event_loop(None)
-#         loop.close()
-#     return True
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    if "asyncio" not in pyfuncitem.keywords:
+        return None
+
+    test_func = pyfuncitem.obj
+    if not inspect.iscoroutinefunction(test_func):
+        return None
+
+    sig = inspect.signature(test_func)
+    call_kwargs = {name: pyfuncitem.funcargs[name] for name in sig.parameters}
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(test_func(**call_kwargs))
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+    return True

--- a/utils/chapter_utils.py
+++ b/utils/chapter_utils.py
@@ -791,8 +791,19 @@ def _adjust_real_number(raw_num: int | None, fallback: int, offset: int) -> int:
     return max(1, adjusted)
 
 
-def get_missing_chapters(story_folder: str, chapters: list[dict], site_key: str) -> list[dict]:
-    """Identify chapters that are missing locally based on sequential numbering."""
+def get_missing_chapters(
+    story_folder: str,
+    chapters: list[dict],
+    site_key: str | None = None,
+) -> list[dict]:
+    """Identify chapters that are missing locally based on sequential numbering.
+
+    The ``site_key`` argument used to be mandatory for integration with some
+    workers, but several callers – including a number of tests – only rely on
+    the first two parameters.  Making the third argument optional keeps the
+    public API backward compatible while allowing existing usages to function
+    without providing an unused value.
+    """
 
     chapter_items = _load_chapter_items(story_folder, chapters)
     if not chapter_items:


### PR DESCRIPTION
## Summary
- re-enable the custom pytest hook so coroutine-based tests run without pytest-asyncio
- make `get_missing_chapters` accept an optional `site_key` argument to preserve backwards compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfed9a5fd883299f862a4c862e78bc