### PR TITLE
Handle tangthuvien redirects and improve crawl observability

### DIFF
--- a/adapters/tangthuvien_adapter.py
+++ b/adapters/tangthuvien_adapter.py
@@ -240,6 +240,7 @@ class TangThuVienAdapter(BaseSiteAdapter):
             return []
 
         chapters = list(details.get("chapters") or [])
+        chapter_source = "details"
         if not chapters:
             expected = None
             if isinstance(total_chapters, int):
@@ -255,6 +256,7 @@ class TangThuVienAdapter(BaseSiteAdapter):
             )
             if chapters:
                 details["chapters"] = chapters
+                chapter_source = "api"
 
         if not chapters:
             html = await self._fetch_text(story_url, wait_for_selector="div.book-info")
@@ -262,6 +264,7 @@ class TangThuVienAdapter(BaseSiteAdapter):
                 logger.error(f"[{self.site_key}] Fallback HTML fetch failed for {story_url}.")
                 return []
             chapters = parse_chapter_list(html, self.base_url)
+            chapter_source = "html"
 
         for chapter in chapters:
             chapter.setdefault("site_key", self.site_key)
@@ -281,7 +284,11 @@ class TangThuVienAdapter(BaseSiteAdapter):
                     f"[{self.site_key}] Applying chapter page limit: keeping first {limit}/{len(chapters)} entries."
                 )
                 chapters = chapters[:limit]
+                chapter_source = f"{chapter_source}-trimmed"
 
+        logger.info(
+            f"[{self.site_key}] Retrieved {len(chapters)} chapters for '{story_title}' from {chapter_source}."
+        )
         return chapters
 
 

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -40,6 +40,7 @@ from utils.logger import logger
 
 def get_async_client_for_proxy(proxy_url):
     return httpx.AsyncClient(
+        follow_redirects=True,
         mounts={
             "http://": httpx.AsyncHTTPTransport(proxy=proxy_url),
             "https://": httpx.AsyncHTTPTransport(proxy=proxy_url),
@@ -60,7 +61,11 @@ async def fetch(
 
         proxy_url = get_proxy_url(GLOBAL_PROXY_USERNAME, GLOBAL_PROXY_PASSWORD)
         try:
-            client_kwargs = {'headers': headers, 'timeout': timeout}
+            client_kwargs = {
+                'headers': headers,
+                'timeout': timeout,
+                'follow_redirects': True,
+            }
             if USE_PROXY and proxy_url:
                 async with get_async_client_for_proxy(proxy_url) as client:
                     if method.upper() == 'POST':


### PR DESCRIPTION
## Summary
- ensure the HTTP client follows redirects so tangthuvien category and chapter pages resolve without repeated 302 warnings
- add logging that reports how many tangthuvien chapters were collected and from which source to simplify log verification

## Testing
- pytest tests/test_tangthuvien_parse.py

------
https://chatgpt.com/codex/tasks/task_e_68dffad31c6c832994395a4f9924290a