### PR TITLE
Add configuration to restrict crawler to selected sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ Một project crawl truyện nâng cao, hỗ trợ async, đa nguồn, đa thể
     PROXIES_FOLDER=proxies
     TELEGRAM_BOT_TOKEN=your_telegram_bot_token
     TELEGRAM_CHAT_ID=your_telegram_chat_id
+    ENABLED_SITE_KEYS=tangthuvien
     # ... các biến khác (xem file config.py hoặc file cấu hình liên quan)
     ```
+
+    > 🆕 `ENABLED_SITE_KEYS` nhận danh sách site (phân tách bởi dấu phẩy) được phép crawl. 
+    > Ví dụ `ENABLED_SITE_KEYS=tangthuvien` sẽ chỉ bật crawler cho TangThuVien giúp bạn kiểm tra hoạt động trước khi mở rộng sang các nguồn khác.
 
 3.  **Chuẩn bị proxy:**
     * Thêm danh sách proxy vào thư mục `proxies/` (ví dụ: `proxies/proxies.txt`).

--- a/config/config.py
+++ b/config/config.py
@@ -13,6 +13,24 @@ BASE_URLS = {
     "tangthuvien": os.getenv("BASE_TANGTHUVIEN", "https://tangthuvien.net"),
 }
 
+# Allow restricting the active crawl sites via environment variable.
+ENABLED_SITE_KEYS = [
+    key.strip()
+    for key in os.getenv("ENABLED_SITE_KEYS", "").split(",")
+    if key.strip()
+]
+
+if ENABLED_SITE_KEYS:
+    filtered_base_urls = {key: BASE_URLS[key] for key in ENABLED_SITE_KEYS if key in BASE_URLS}
+    missing_sites = [key for key in ENABLED_SITE_KEYS if key not in BASE_URLS]
+    if missing_sites:
+        raise ValueError(
+            "ENABLED_SITE_KEYS contains unsupported site(s): " + ", ".join(missing_sites)
+        )
+    if not filtered_base_urls:
+        raise ValueError("No valid site keys found in ENABLED_SITE_KEYS")
+    BASE_URLS = filtered_base_urls
+
 # ============ CRAWL CONFIG ============
 REQUEST_DELAY = float(os.getenv("REQUEST_DELAY", "5"))
 TIMEOUT_REQUEST = int(os.getenv("TIMEOUT_REQUEST", 30))


### PR DESCRIPTION
## Summary
- add support for the `ENABLED_SITE_KEYS` environment variable to limit the active crawl sites
- document how to enable only the TangThuVien crawler for validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00107e4d083299040bad7f90406f4