### PR TITLE
Ensure crawl state files are site-specific

### DIFF
--- a/main.py
+++ b/main.py
@@ -557,7 +557,7 @@ async def process_story_item(
         crawl_state["processed_chapter_urls_for_current_story"] = []
     crawl_state["previous_story_url_in_state_for_chapters"] = story_data_item["url"]
     state_file = get_state_file(site_key)
-    await save_crawl_state(crawl_state, state_file)
+    await save_crawl_state(crawl_state, state_file, site_key=site_key)
 
     # 2. Crawl tất cả nguồn cho đến khi đủ chương
     chapter_limit_hint = await crawl_all_sources_until_full(
@@ -694,7 +694,7 @@ async def process_story_item(
         crawl_state["globally_completed_story_urls"] = sorted(completed)
     backup_crawl_state(state_file)
     state_file = get_state_file(site_key)
-    await save_crawl_state(crawl_state, state_file)
+    await save_crawl_state(crawl_state, state_file, site_key=site_key)
     await clear_specific_state_keys(
         crawl_state, ["processed_chapter_urls_for_current_story"], state_file
     )
@@ -807,7 +807,7 @@ async def process_genre_item(
         crawl_state["current_story_index_in_genre"] = 0
     crawl_state["previous_genre_url_in_state_for_stories"] = genre_data["url"]
     state_file = get_state_file(site_key)
-    await save_crawl_state(crawl_state, state_file)
+    await save_crawl_state(crawl_state, state_file, site_key=site_key)
 
     retry_time = 0
     max_retry = 5
@@ -924,7 +924,7 @@ async def process_genre_item(
                 await smart_delay()
         crawl_state["globally_completed_story_urls"] = sorted(completed_global)
         crawl_state["current_story_index_in_genre"] = batch[-1][0] + 1
-        await save_crawl_state(crawl_state, state_file)
+        await save_crawl_state(crawl_state, state_file, site_key=site_key)
         if skipped_in_batch:
             logger.warning(
                 "[BATCH] Các truyện bị skip trong batch này: " + ", ".join(skipped_in_batch)

--- a/tests/test_state_utils.py
+++ b/tests/test_state_utils.py
@@ -15,7 +15,7 @@ async def test_save_and_load_crawl_state(tmp_path):
     }
 
     # Save the state
-    await save_crawl_state(sample_state, str(state_file))
+    await save_crawl_state(sample_state, str(state_file), site_key="test_site")
 
     # Load the state
     loaded_state = await load_crawl_state(str(state_file), "test_site")
@@ -47,7 +47,7 @@ async def test_clear_specific_state_keys(tmp_path):
     }
 
     # Save initial state
-    await save_crawl_state(initial_state, str(state_file), debounce=0)
+    await save_crawl_state(initial_state, str(state_file), debounce=0, site_key="test_site")
 
     # The state is modified in-place
     state_to_modify = initial_state.copy()
@@ -67,3 +67,16 @@ async def test_clear_specific_state_keys(tmp_path):
     assert "current_genre_url" not in persisted_state
     assert "current_story_index_in_genre" not in persisted_state
     assert persisted_state["to_keep"] == "this should remain"
+    assert persisted_state["site_key"] == "test_site"
+
+
+@pytest.mark.asyncio
+async def test_ignore_state_with_mismatched_site(tmp_path):
+    """Loading a state file for a different site should reset the state."""
+    state_file = tmp_path / "state.json"
+    sample_state = {"current_genre_url": "https://example.com"}
+    await save_crawl_state(sample_state, str(state_file), site_key="xtruyen")
+
+    loaded_state = await load_crawl_state(str(state_file), "tangthuvien")
+
+    assert loaded_state == {}

--- a/utils/chapter_utils.py
+++ b/utils/chapter_utils.py
@@ -222,7 +222,7 @@ async def crawl_missing_chapters_for_story(
             tasks.append(asyncio.create_task(wrapped()))
         await asyncio.gather(*tasks, return_exceptions=True)
         if state_file:
-            await save_crawl_state(crawl_state, state_file)
+            await save_crawl_state(crawl_state, state_file, site_key=site_key)
         return successful, failed
 
     while retry_count < normal_rounds:
@@ -502,7 +502,11 @@ async def async_download_and_save_chapter(
                     processed.append(url)
                     crawl_state['processed_chapter_urls_for_current_story'] = processed
                     file_to_save = state_file or get_state_file(site_key)
-                    await save_crawl_state(crawl_state, file_to_save)
+                    await save_crawl_state(
+                        crawl_state,
+                        file_to_save,
+                        site_key=site_key,
+                    )
         except Exception as e:
             logger.error(f"          Loi luu '{chapter_filename_only}': {e}")
             await log_error_chapter({


### PR DESCRIPTION
## Summary
- tag each saved crawl state with its associated site key and ignore mismatched states when loading
- pass the site key when saving crawl state from the crawler and chapter utilities
- extend state utility tests to cover the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00686aae8832982829648ebbb1b9e