### PR TITLE
Sanitize base URLs to avoid malformed crawler requests

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,16 +1,43 @@
 import os
 import asyncio
 import re
+from typing import Optional
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
+
 from config.useragent_list import STATIC_USER_AGENTS
 
 # Load env từ .env hoặc hệ thống
 load_dotenv()
 
+def _sanitize_base_url(raw_value: Optional[str], default: str) -> str:
+    """Normalize BASE_URL style inputs to avoid malformed URLs."""
+
+    candidate = (raw_value or default).strip()
+    if not candidate:
+        return default
+
+    # Remove accidental trailing punctuation that can break requests (e.g. '!').
+    candidate = candidate.rstrip("!?#'\"")
+    # Strip trailing slashes while keeping scheme separators intact.
+    candidate = candidate.rstrip("/ \t\n\r")
+
+    if not candidate:
+        return default
+
+    parsed = urlparse(candidate)
+    if not parsed.scheme:
+        # Fall back to default if the provided value is missing a scheme.
+        return default
+
+    return candidate
+
+
 # ============ BASE URLs ============
 BASE_URLS = {
-    "xtruyen": os.getenv("BASE_XTRUYEN", "https://xtruyen.vn"),
-    "tangthuvien": os.getenv("BASE_TANGTHUVIEN", "https://tangthuvien.net"),
+    "xtruyen": _sanitize_base_url(os.getenv("BASE_XTRUYEN"), "https://xtruyen.vn"),
+    "tangthuvien": _sanitize_base_url(os.getenv("BASE_TANGTHUVIEN"), "https://tangthuvien.net"),
 }
 
 # Allow restricting the active crawl sites via environment variable.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+
+import pytest
+
+MODULE_NAME = "config.config"
+FOLDER_ENV_KEYS = [
+    "DATA_FOLDER",
+    "COMPLETED_FOLDER",
+    "BACKUP_FOLDER",
+    "STATE_FOLDER",
+    "LOG_FOLDER",
+]
+
+
+def _reload_config(monkeypatch: pytest.MonkeyPatch, tmp_path, base_value: str | None):
+    # Ensure we import a fresh instance of config.config with controlled environment.
+    sys.modules.pop(MODULE_NAME, None)
+
+    for key in FOLDER_ENV_KEYS:
+        monkeypatch.setenv(key, str(tmp_path / key.lower()))
+
+    monkeypatch.setenv("BASE_XTRUYEN", "https://xtruyen.vn")
+    if base_value is None:
+        monkeypatch.delenv("BASE_TANGTHUVIEN", raising=False)
+    else:
+        monkeypatch.setenv("BASE_TANGTHUVIEN", base_value)
+
+    module = importlib.import_module(MODULE_NAME)
+    return module
+
+
+def test_base_url_sanitizes_trailing_punctuation(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    module = _reload_config(monkeypatch, tmp_path, "https://tangthuvien.net/!")
+    try:
+        assert module.BASE_URLS["tangthuvien"] == "https://tangthuvien.net"
+    finally:
+        sys.modules.pop(MODULE_NAME, None)
+
+
+def test_base_url_falls_back_without_scheme(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    module = _reload_config(monkeypatch, tmp_path, "tangthuvien.net")
+    try:
+        assert module.BASE_URLS["tangthuvien"] == "https://tangthuvien.net"
+    finally:
+        sys.modules.pop(MODULE_NAME, None)


### PR DESCRIPTION
## Summary
- sanitize configured BASE_URL values to strip stray punctuation and ensure a valid scheme is present before use
- add regression tests covering URL sanitization and fallback behaviour for the tangthuvien configuration

## Testing
- pytest tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e00afcc92c83299820758e0231e39f