### PR TITLE
Update TangThuVien parsing for new listing structure

### DIFF
--- a/site_info/tangthuvien/genre_modern.html
+++ b/site_info/tangthuvien/genre_modern.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <body>
+    <div class="update-list">
+      <div class="book-wrap">
+        <div class="book-info">
+          <h3><a class="name" href="/doc-truyen/linh-gioi-chi-lu">Linh Giới Chi Lữ</a></h3>
+          <p class="chapter"><a class="section" href="/doc-truyen/linh-gioi-chi-lu/chuong-12">Chương 12</a></p>
+          <p class="author"><a class="writer" href="/tac-gia/linh">Tác Giả Một</a></p>
+        </div>
+      </div>
+      <div class="book-wrap">
+        <div class="book-info">
+          <h3><a class="name" href="/doc-truyen/kiem-hiep-truyen">Kiếm Hiệp Truyện</a></h3>
+          <p class="chapter"><a class="section" href="/doc-truyen/kiem-hiep-truyen/chuong-45">Chương 45</a></p>
+          <p class="author"><a class="writer" href="/tac-gia/kiem">Tác Giả Hai</a></p>
+        </div>
+      </div>
+    </div>
+    <div class="pagination">
+      <a href="?page=1">1</a>
+      <a href="?page=2">2</a>
+      <a href="?page=3">3</a>
+    </div>
+  </body>
+</html>

--- a/tests/test_tangthuvien_parse.py
+++ b/tests/test_tangthuvien_parse.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from analyze.tangthuvien_parse import (
+    find_genre_listing_url,
     parse_chapter_content,
     parse_chapter_list,
     parse_genres,
@@ -24,6 +25,13 @@ def test_parse_genres_includes_tien_hiep():
     assert "Tiên Hiệp" in names
     tien_hiep = next(g for g in genres if g["name"] == "Tiên Hiệp")
     assert tien_hiep["url"].startswith("https://tangthuvien.net/the-loai/tien-hiep")
+
+
+def test_find_genre_listing_url_prefers_full_listing():
+    html = _load("home.txt")
+    listing_url = find_genre_listing_url(html, "https://tangthuvien.net")
+
+    assert listing_url == "https://tangthuvien.net/tong-hop?tp=cv&ctg=1"
 
 
 def test_parse_story_list_extracts_rows():
@@ -63,6 +71,12 @@ def test_parse_story_info_captures_metadata():
     assert info["total_chapters_on_site"] == 689
     assert isinstance(info.get("chapters"), list)
     assert any(g["name"] == "Tiên Hiệp" for g in info["categories"])
+    assert info["stats"]["likes"] == 22
+    assert info["stats"]["views"] == 370845
+    assert "Tu chân" in info["tags"]
+    latest = info["latest_chapters"]
+    assert len(latest) >= 5
+    assert latest[0]["url"].endswith("/chuong-689")
 
 
 def test_parse_chapter_list_from_ajax_snippet():


### PR DESCRIPTION
## Summary
- resolve TangThuVien genre pages to the /tong-hop listing endpoint and cache the result for pagination
- enhance TangThuVien parsing to score listing links and capture stats, tags, and latest chapter metadata
- cover the new parsing paths with parser tests and a synthetic card-layout fixture

## Testing
- pytest tests/test_tangthuvien_parse.py tests/test_tangthuvien_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68e00ca3e3188329bc5068bc3cc453e7