### PR TITLE
Force desktop headers when crawling TangThuVien

### DIFF
--- a/adapters/tangthuvien_adapter.py
+++ b/adapters/tangthuvien_adapter.py
@@ -49,16 +49,35 @@ def _with_page_parameter(url: str, page: int) -> str:
 
 class TangThuVienAdapter(BaseSiteAdapter):
     _CHAPTER_PAGE_SIZE = 75
+    _DESKTOP_USER_AGENT = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    )
 
     def __init__(self) -> None:
         self.site_key = "tangthuvien"
-        self.base_url = BASE_URLS.get(self.site_key, "https://tangthuvien.net")
+        configured_base_url = BASE_URLS.get(self.site_key, "https://tangthuvien.net")
+        desktop_candidate = self._compute_desktop_base_url(configured_base_url)
+
+        self._configured_base_url = configured_base_url
+        self.base_url = desktop_candidate or configured_base_url
+        self._desktop_base_url = desktop_candidate
+        self._request_headers = {"User-Agent": self._DESKTOP_USER_AGENT}
+
+        if desktop_candidate and desktop_candidate != configured_base_url:
+            logger.debug(
+                "[tangthuvien] Using desktop domain %s instead of configured %s",
+                desktop_candidate,
+                configured_base_url,
+            )
+
         self._details_cache: Dict[str, Dict[str, Any]] = {}
         self._details_lock = asyncio.Lock()
         self._genre_listing_cache: Dict[str, str] = {}
         self._genre_listing_lock = asyncio.Lock()
 
-    def _compute_desktop_base_url(self) -> Optional[str]:
+    @staticmethod
+    def _compute_desktop_base_url(base_url: str) -> Optional[str]:
         """Return a best-effort desktop version of ``self.base_url``.
 
         TangThuVien serves a distinct mobile experience from ``m.tangthuvien``
@@ -67,7 +86,7 @@ class TangThuVienAdapter(BaseSiteAdapter):
         the desktop domain so that genre discovery keeps working.
         """
 
-        parsed = urlparse(self.base_url)
+        parsed = urlparse(base_url)
         hostname = parsed.hostname or ""
 
         replacement_host = None
@@ -116,16 +135,21 @@ class TangThuVienAdapter(BaseSiteAdapter):
             genres = parse_genres(html, self.base_url)
 
         if not genres:
-            desktop_base = self._compute_desktop_base_url()
-            if desktop_base and desktop_base != self.base_url:
+            fallback_base = None
+            if self.base_url != self._configured_base_url:
+                fallback_base = self._configured_base_url
+            elif self._desktop_base_url and self._desktop_base_url != self.base_url:
+                fallback_base = self._desktop_base_url
+
+            if fallback_base:
                 fallback_html = await self._fetch_text(
-                    desktop_base, wait_for_selector="div.update-wrap"
+                    fallback_base, wait_for_selector="div.update-wrap"
                 )
                 if fallback_html:
-                    genres = parse_genres(fallback_html, desktop_base)
+                    genres = parse_genres(fallback_html, fallback_base)
                     if genres:
                         logger.debug(
-                            f"[{self.site_key}] Fallback to desktop domain {desktop_base} for genres"
+                            f"[{self.site_key}] Fallback to alternate domain {fallback_base} for genres"
                         )
 
         logger.info(f"[{self.site_key}] Found {len(genres)} genres")
@@ -156,8 +180,24 @@ class TangThuVienAdapter(BaseSiteAdapter):
             self._genre_listing_cache[normalized] = resolved
         return resolved
 
+    def _build_request_headers(self, url: str) -> Dict[str, str]:
+        parsed = urlparse(url)
+        if parsed.scheme and parsed.netloc:
+            referer = f"{parsed.scheme}://{parsed.netloc}/"
+        else:
+            referer = self.base_url.rstrip("/") + "/"
+
+        headers = dict(self._request_headers)
+        headers["Referer"] = referer
+        return headers
+
     async def _fetch_text(self, url: str, wait_for_selector: Optional[str] = None) -> Optional[str]:
-        response = await make_request(url, self.site_key, wait_for_selector=wait_for_selector)
+        response = await make_request(
+            url,
+            self.site_key,
+            wait_for_selector=wait_for_selector,
+            extra_headers=self._build_request_headers(url),
+        )
         if isinstance(response, str):
             return response
         if response and getattr(response, "text", None):
@@ -240,7 +280,11 @@ class TangThuVienAdapter(BaseSiteAdapter):
                 break
 
             query_url = f"{api_base}?page={page_index}&limit={self._CHAPTER_PAGE_SIZE}&web=1"
-            response = await make_request(query_url, self.site_key)
+            response = await make_request(
+                query_url,
+                self.site_key,
+                extra_headers=self._build_request_headers(query_url),
+            )
             if isinstance(response, str):
                 text_payload = response
             elif response and getattr(response, "text", None):


### PR DESCRIPTION
## Summary
- detect when the configured TangThuVien base URL points to the mobile hostname
- automatically switch to the desktop domain for crawling to keep genre parsing working
- retain the mobile URL as a fallback if the desktop content fails to load
- force TangThuVien requests to send a desktop user agent and referer so the site stops serving the mobile layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e084bc51f48329b40c72bff9f8fea7