### PR TITLE
Fix TangThuVien URL normalization and missing imports

### DIFF
--- a/adapters/tangthuvien_adapter.py
+++ b/adapters/tangthuvien_adapter.py
@@ -119,7 +119,14 @@ class TangThuVienAdapter(BaseSiteAdapter):
 
         if not normalized_path.lower().startswith("/doc-truyen/"):
             alias = normalized_path.strip("/")
-            normalized_path = f"/doc-truyen/{alias}" if alias else "/doc-truyen"
+            parts = [segment for segment in alias.split("/") if segment]
+            if parts and parts[0].lower() == "tong-hop":
+                parts = parts[1:]
+            alias = "/".join(parts)
+            if alias:
+                normalized_path = f"/doc-truyen/{alias}"
+            else:
+                normalized_path = "/doc-truyen"
 
         normalized = parsed._replace(path=normalized_path)
         return urlunparse(normalized)

--- a/main.py
+++ b/main.py
@@ -1072,7 +1072,7 @@ async def run_crawler(
     settings: WorkerSettings,
     crawl_state: Optional[Dict[str, Any]] = None,
 ):
-    state_file = get_state_file(site_key)
+    state_file = app_config.get_state_file(site_key)
     crawl_state = crawl_state or await load_crawl_state(state_file, site_key)
     total_genres = len(genres)
     genres_done = 0

--- a/workers/crawler_missing_chapter.py
+++ b/workers/crawler_missing_chapter.py
@@ -4,6 +4,7 @@ import json
 import datetime
 import re
 import traceback
+import shutil
 from typing import cast
 from adapters.factory import get_adapter
 from config import config as app_config


### PR DESCRIPTION
## Summary
- ensure TangThuVien story detail URLs drop the `/tong-hop` segment so requests hit `/doc-truyen/<alias>`
- fix crawler state loading by referencing the app configuration helper for the state file
- add the missing `shutil` import when cleaning up failed autofix folders

## Testing
- pytest tests/test_tangthuvien_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68e08b9591588329a6a2e02d75f432f0