### PR TITLE
Ensure TangThuVien requests always use desktop user agents

### DIFF
--- a/adapters/tangthuvien_adapter.py
+++ b/adapters/tangthuvien_adapter.py
@@ -188,7 +188,7 @@ class TangThuVienAdapter(BaseSiteAdapter):
         else:
             referer = self.base_url.rstrip("/") + "/"
 
-        headers = await get_random_headers(self.site_key)
+        headers = await get_random_headers(self.site_key, desktop_only=True)
         headers["Referer"] = referer
         return headers
 

--- a/scraper.py
+++ b/scraper.py
@@ -123,10 +123,13 @@ async def _make_request_playwright(
     timeout: int = 30,
     max_retries: int = 5,
     wait_for_selector: str | None = None,
+    extra_headers: Optional[Dict[str, str]] = None,
 ):
     """Load trang bằng Playwright."""
     global browser
     headers = await get_random_headers(site_key)
+    if extra_headers:
+        headers.update(extra_headers)
     last_exception = None
 
     if async_playwright is None:
@@ -363,4 +366,11 @@ async def make_request(
             return resp
     logger.info("[request] Fallback to Playwright due to block or bad status")
     fallback_stats["fallback_count"][site_key] += 1
-    return await _make_request_playwright(url, site_key, timeout, max_retries, wait_for_selector=wait_for_selector)
+    return await _make_request_playwright(
+        url,
+        site_key,
+        timeout,
+        max_retries,
+        wait_for_selector=wait_for_selector,
+        extra_headers=extra_headers,
+    )


### PR DESCRIPTION
## Summary
- add desktop-only filtering to the shared random user-agent helper and expose it via get_random_headers
- update the TangThuVien adapter to request desktop headers while keeping randomized user agents
- pass adapter-provided headers through Playwright fallbacks so the browser context keeps the desktop agent

## Testing
- `pytest tests/test_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68e095257d908329928373a15e1d8b3a