### PR TITLE
Handle missing titles in slugify helper

### DIFF
--- a/tests/test_chapter_utils.py
+++ b/tests/test_chapter_utils.py
@@ -17,6 +17,10 @@ def test_slugify_title_basic():
     assert slugify_title('Hello world!? 123') == 'hello-world-123'
 
 
+def test_slugify_title_handles_none():
+    assert slugify_title(None) == ""
+
+
 def test_extract_real_chapter_number_variants():
     assert extract_real_chapter_number('Chương 12') == 12
     assert extract_real_chapter_number('Chapter 5') == 5

--- a/utils/chapter_utils.py
+++ b/utils/chapter_utils.py
@@ -894,7 +894,10 @@ def get_missing_chapters(
     return missing
 
 
-def slugify_title(title: str) -> str:
+def slugify_title(title: Optional[str]) -> str:
+    if not title:
+        return ""
+
     s = unidecode(title)
     s = re.sub(r'[^\w\s-]', '', s.lower())  # bo ky tu dac biet, lowercase
     s = re.sub(r'[\s]+', '-', s)            # khoang trang thanh dau -


### PR DESCRIPTION
## Summary
- avoid crashes when slugifying missing chapter titles by treating falsy values as empty strings
- add a regression test ensuring slugify_title returns an empty slug for None input

## Testing
- pytest tests/test_chapter_utils.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0997db98483298bd2cb45fd235503