### PR TITLE
Add auto-discovery plugin system for site adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /completed_stories/
 *.pyc
 *.json
+!config/sites/
+!config/sites/*.json
 /backup/
 /backup_truyen_data/
 /tmp_data/*

--- a/adapters/base_site_adapter.py
+++ b/adapters/base_site_adapter.py
@@ -1,6 +1,24 @@
 from abc import ABC, abstractmethod
+from typing import ClassVar
+
 
 class BaseSiteAdapter(ABC):
+    """Base contract that all site adapters must follow."""
+
+    #: Identifier used by the plugin loader to register the adapter.
+    site_key: ClassVar[str]
+
+    @classmethod
+    def get_site_key(cls) -> str:
+        """Return the declared ``site_key`` for the adapter."""
+
+        key = getattr(cls, "site_key", "")
+        if not isinstance(key, str) or not key:
+            raise NotImplementedError(
+                f"Adapter {cls.__name__} must define a non-empty `site_key` class attribute."
+            )
+        return key
+
     @abstractmethod
     async def get_genres(self):
         pass
@@ -26,7 +44,7 @@ class BaseSiteAdapter(ABC):
         pass
 
     @abstractmethod
-    async def get_all_stories_from_genre_with_page_check(self, genre_name, genre_url, site_key,max_pages=None):
+    async def get_all_stories_from_genre_with_page_check(self, genre_name, genre_url, site_key, max_pages=None):
         pass
 
     def get_chapters_per_page_hint(self) -> int:

--- a/adapters/factory.py
+++ b/adapters/factory.py
@@ -1,9 +1,15 @@
-def get_adapter(site_key: str):
-    if site_key == "xtruyen":
-        from adapters.xtruyen_adapter import XTruyenAdapter
-        return XTruyenAdapter()
-    if site_key == "tangthuvien":
-        from adapters.tangthuvien_adapter import TangThuVienAdapter
-        return TangThuVienAdapter()
-    raise ValueError(f"Unknown site: {site_key}")
+"""Factory helpers for retrieving site adapters."""
 
+from adapters.registry import adapter_registry
+
+
+def get_adapter(site_key: str):
+    """Return an adapter instance registered for ``site_key``."""
+
+    return adapter_registry.get(site_key)
+
+
+def available_site_keys():
+    """Return the discovered site keys that can be instantiated."""
+
+    return list(adapter_registry.available_site_keys())

--- a/adapters/registry.py
+++ b/adapters/registry.py
@@ -1,0 +1,99 @@
+"""Automatic discovery and registration for site adapters."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from types import ModuleType
+from typing import Dict, Iterable, Optional, Type
+
+from adapters.base_site_adapter import BaseSiteAdapter
+
+_ADAPTER_MODULE_PREFIX = "adapters."
+_ADAPTER_SUFFIX = "_adapter"
+
+
+class AdapterRegistry:
+    """Registry that discovers and instantiates site adapters on demand."""
+
+    def __init__(self) -> None:
+        self._adapter_classes: Dict[str, Type[BaseSiteAdapter]] = {}
+        self._is_discovered = False
+
+    def register(self, adapter_cls: Type[BaseSiteAdapter]) -> None:
+        """Register an adapter class provided by discovery or manual hooks."""
+
+        if not inspect.isclass(adapter_cls) or not issubclass(adapter_cls, BaseSiteAdapter):
+            raise TypeError("Adapter must be a subclass of BaseSiteAdapter")
+
+        site_key = adapter_cls.get_site_key()
+        if site_key in self._adapter_classes:
+            existing = self._adapter_classes[site_key]
+            if existing is adapter_cls:
+                return
+            raise ValueError(
+                f"Duplicate adapter registration for site '{site_key}': "
+                f"{existing.__module__}.{existing.__name__} already registered"
+            )
+
+        self._adapter_classes[site_key] = adapter_cls
+
+    def available_site_keys(self) -> Iterable[str]:
+        """Return the discovered site keys."""
+
+        self._ensure_discovered()
+        return sorted(self._adapter_classes.keys())
+
+    def get(self, site_key: str) -> BaseSiteAdapter:
+        """Instantiate the adapter registered for ``site_key``."""
+
+        self._ensure_discovered()
+        try:
+            adapter_cls = self._adapter_classes[site_key]
+        except KeyError as exc:
+            raise ValueError(f"Unknown site: {site_key}") from exc
+        return adapter_cls()
+
+    # ------------------------------------------------------------------
+    # Discovery helpers
+
+    def _ensure_discovered(self) -> None:
+        if not self._is_discovered:
+            self._discover_adapters()
+            self._is_discovered = True
+
+    def _discover_adapters(self) -> None:
+        """Find adapter implementations under the ``adapters`` package."""
+
+        package = importlib.import_module("adapters")
+        package_path = getattr(package, "__path__", [])
+
+        for module_info in pkgutil.iter_modules(package_path, _ADAPTER_MODULE_PREFIX):
+            module_name = module_info.name
+            if not module_name.endswith(_ADAPTER_SUFFIX):
+                continue
+            module = self._import_module(module_name)
+            if module is None:
+                continue
+            self._register_module_adapters(module)
+
+    def _import_module(self, module_name: str) -> Optional[ModuleType]:
+        try:
+            return importlib.import_module(module_name)
+        except Exception:
+            # Import errors should not prevent other adapters from loading.
+            return None
+
+    def _register_module_adapters(self, module: ModuleType) -> None:
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if not issubclass(obj, BaseSiteAdapter) or obj is BaseSiteAdapter:
+                continue
+            if obj.__module__ != module.__name__:
+                continue
+            self.register(obj)
+
+
+adapter_registry = AdapterRegistry()
+
+__all__ = ["adapter_registry", "AdapterRegistry"]

--- a/config/sites/tangthuvien.json
+++ b/config/sites/tangthuvien.json
@@ -1,0 +1,6 @@
+{
+  "display_name": "Tang Thu Vien",
+  "chapter_page_size": 75,
+  "genre_paging_fallback_step": 5,
+  "genre_paging_fallback_max": 50
+}

--- a/config/sites/xtruyen.json
+++ b/config/sites/xtruyen.json
@@ -1,0 +1,5 @@
+{
+  "display_name": "XTruyen",
+  "chapter_list_batch": 100,
+  "ajax_endpoint": "/wp-admin/admin-ajax.php"
+}

--- a/docs/ADDING_NEW_ADAPTER.md
+++ b/docs/ADDING_NEW_ADAPTER.md
@@ -1,0 +1,58 @@
+# Adding a new site adapter
+
+This project now discovers adapters automatically. Follow the steps below to
+integrate a new source without touching the core factory logic.
+
+## 1. Create a module
+
+Create a new file in `adapters/` whose name ends with `_adapter.py` (for
+example `my_site_adapter.py`). The automatic discovery system scans for files
+matching this naming convention.
+
+Inside the module implement a class that inherits from
+`adapters.base_site_adapter.BaseSiteAdapter` and define a unique `site_key`
+class attribute:
+
+```python
+from adapters.base_site_adapter import BaseSiteAdapter
+
+
+class MySiteAdapter(BaseSiteAdapter):
+    site_key = "mysite"
+
+    async def get_genres(self):
+        ...
+```
+
+Every abstract method declared on `BaseSiteAdapter` must be implemented. The
+`site_key` attribute is mandatory and is used by the factory when instantiating
+adapters.
+
+## 2. Provide optional configuration
+
+Per-site configuration values can be placed in `config/sites/<site_key>.json`.
+Adapters can read these values via `utils.site_config.load_site_config`. Use
+this mechanism to store selectors, API endpoints, or other tweakable settings so
+that adding new sites requires minimal code changes. The loader also supports an
+override through the `SITE_CONFIG_DIR` environment variable if you need to point
+to a different configuration directory at runtime.
+
+A minimal configuration file might look like:
+
+```json
+{
+  "display_name": "My Site",
+  "chapter_page_size": 42
+}
+```
+
+## 3. Instantiate the adapter
+
+Callers can retrieve the adapter instance by invoking
+`adapters.factory.get_adapter("mysite")`. The factory relies on the automatic
+registry and therefore requires no further edits when new adapters are added.
+You can inspect the available site keys through
+`adapters.factory.available_site_keys()`.
+
+By following these steps, new adapters can be introduced without modifying the
+core crawling code, making the system easier to extend and maintain.

--- a/utils/site_config.py
+++ b/utils/site_config.py
@@ -1,0 +1,40 @@
+"""Helpers for loading per-site configuration values."""
+
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from typing import Any, Dict
+
+SITE_CONFIG_ENV = "SITE_CONFIG_DIR"
+DEFAULT_SITE_CONFIG_DIR = os.path.join(os.path.dirname(__file__), "..", "config", "sites")
+
+
+@lru_cache(maxsize=None)
+def load_site_config(site_key: str) -> Dict[str, Any]:
+    """Load a JSON configuration file for ``site_key`` if it exists."""
+
+    config_dir = os.environ.get(SITE_CONFIG_ENV)
+    if not config_dir:
+        config_dir = os.path.abspath(DEFAULT_SITE_CONFIG_DIR)
+    else:
+        config_dir = os.path.abspath(config_dir)
+
+    candidate = os.path.join(config_dir, f"{site_key}.json")
+    if not os.path.exists(candidate):
+        return {}
+
+    with open(candidate, "r", encoding="utf-8") as fh:
+        try:
+            data = json.load(fh)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in site config '{candidate}': {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Site config '{candidate}' must contain a JSON object")
+
+    return data
+
+
+__all__ = ["load_site_config", "SITE_CONFIG_ENV"]


### PR DESCRIPTION
## Summary
- add a registry that auto-discovers adapter implementations and expose helper APIs for consumers
- load per-site configuration from JSON files so adapters can adjust behaviour without code changes
- document the adapter integration workflow for contributors

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0e65371c0832993b287e936c77a6d