### PR TITLE
Add genre progress tracking and dashboard reporting

### DIFF
--- a/adapters/tangthuvien_adapter.py
+++ b/adapters/tangthuvien_adapter.py
@@ -16,6 +16,7 @@ from config.config import BASE_URLS, get_random_headers
 from scraper import make_request
 from utils.chapter_utils import get_chapter_sort_key
 from utils.logger import logger
+from utils.metrics_tracker import metrics_tracker
 from utils.site_config import load_site_config
 
 
@@ -266,6 +267,14 @@ class TangThuVienAdapter(BaseSiteAdapter):
             logger.warning(f"[{self.site_key}] No stories detected on first page of {genre_name}")
             return [], 0, 0
 
+        metrics_tracker.update_genre_pages(
+            site_key,
+            genre_url,
+            crawled_pages=1,
+            total_pages=total_pages,
+            current_page=1,
+        )
+
         all_stories = list(first_page_stories)
         seen_urls: Set[str] = set()
         for story in all_stories:
@@ -307,6 +316,13 @@ class TangThuVienAdapter(BaseSiteAdapter):
 
             stories, _ = await self.get_stories_in_genre(genre_url, page_number)
             crawled_pages += 1
+            metrics_tracker.update_genre_pages(
+                site_key,
+                genre_url,
+                crawled_pages=crawled_pages,
+                total_pages=total_pages,
+                current_page=page_number,
+            )
             if not stories:
                 logger.info(
                     f"[{self.site_key}] Stop paging {genre_name}: empty page {page_number}"

--- a/adapters/xtruyen_adapter.py
+++ b/adapters/xtruyen_adapter.py
@@ -15,6 +15,7 @@ from config.config import BASE_URLS
 from scraper import make_request
 from utils.chapter_utils import get_chapter_sort_key
 from utils.logger import logger
+from utils.metrics_tracker import metrics_tracker
 from utils.site_config import load_site_config
 
 
@@ -253,6 +254,14 @@ class XTruyenAdapter(BaseSiteAdapter):
             logger.warning(f"[{self.site_key}] No stories detected on first page of {genre_name}")
             return [], 0, 0
 
+        metrics_tracker.update_genre_pages(
+            site_key,
+            genre_url,
+            crawled_pages=1,
+            total_pages=total_pages,
+            current_page=1,
+        )
+
         all_stories = list(first_page_stories)
         limit = max_pages or total_pages or 1
         crawled_pages = 1
@@ -260,6 +269,13 @@ class XTruyenAdapter(BaseSiteAdapter):
         for page in range(2, limit + 1):
             stories, _ = await self.get_stories_in_genre(genre_url, page)
             crawled_pages += 1
+            metrics_tracker.update_genre_pages(
+                site_key,
+                genre_url,
+                crawled_pages=crawled_pages,
+                total_pages=total_pages,
+                current_page=page,
+            )
             if not stories:
                 logger.info(f"[{self.site_key}] Stop paging {genre_name}: empty page {page}")
                 break


### PR DESCRIPTION
## Summary
- extend the metrics tracker with genre-level progress, aggregation, and persistence helpers
- update the crawler, adapters, and dashboards to surface genre/page/story progress in CLI and Telegram outputs
- add regression tests covering the new genre tracking snapshot data

## Testing
- pytest tests/utils/test_metrics_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f69b46ac8329ae3fc34d15a7c15e