### PR TITLE
Fix Telegram menu fallback when edit fails

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -69,13 +69,24 @@ async def show_main_menu(update: Update, text: str | None = None, edit: bool = F
     if edit and callback_query:
         try:
             await callback_query.edit_message_text(menu_text, reply_markup=markup)
+            return
         except BadRequest as exc:
-            if "message is not modified" not in str(exc).lower():
-                raise
-    else:
-        message = update.effective_message
-        if message:
-            await message.reply_text(menu_text, reply_markup=markup)
+            error_text = str(exc).lower()
+            if "message is not modified" in error_text:
+                return
+            logger.warning(
+                "[Bot] Không thể chỉnh sửa menu hiện tại (%s). Sẽ gửi menu mới thay thế.",
+                exc,
+            )
+
+    message = update.effective_message
+    if message:
+        await message.reply_text(menu_text, reply_markup=markup)
+        return
+
+    chat = update.effective_chat
+    if chat:
+        await chat.send_message(menu_text, reply_markup=markup)
 
 
 def build_crawl_menu() -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- ensure the Telegram menu falls back to sending a new message when editing the existing inline menu fails
- add logging to highlight when the bot cannot edit the original menu message

## Testing
- pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68e1168de62c8329932cb55ee46845c8