### PR TITLE
Refactor crawl pipeline to use precomputed plans

### DIFF
--- a/core/crawl_planner.py
+++ b/core/crawl_planner.py
@@ -1,0 +1,306 @@
+"""Utilities for building structured crawl plans.
+
+This module encapsulates the *discovery* phase of the crawl so that the core
+pipeline can follow a predictable flow:
+
+1. Lấy danh sách category từ adapter.
+2. Với từng category, lấy toàn bộ truyện cần crawl.
+3. Gom lại thành các ``dict`` ``{category: [story, ...]}`` để chia batch và làm
+   thống kê.
+
+The helpers defined here are used directly by :mod:`main` to prepare crawl
+plans before any heavy processing begins.  They also remain usable in isolation
+for unit tests and tooling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from adapters.base_site_adapter import BaseSiteAdapter
+from config import config as app_config
+from utils.io_utils import log_failed_genre
+from utils.logger import logger
+from utils.metrics_tracker import metrics_tracker
+
+
+def _normalise_genre_name(raw_genre: Dict[str, Any]) -> Optional[str]:
+    """Return a human readable name for ``raw_genre`` if possible."""
+
+    if not isinstance(raw_genre, dict):
+        return None
+
+    for key in ("name", "title", "label", "category"):
+        value = raw_genre.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _normalise_genre_url(raw_genre: Dict[str, Any]) -> Optional[str]:
+    """Return the URL for ``raw_genre`` if it contains one."""
+
+    if not isinstance(raw_genre, dict):
+        return None
+
+    for key in ("url", "link", "href"):
+        value = raw_genre.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+@dataclass(slots=True)
+class CategoryCrawlPlan:
+    """Represents a single category and the stories discovered for it."""
+
+    name: str
+    url: str
+    stories: List[Dict[str, Any]] = field(default_factory=list)
+    total_pages: Optional[int] = None
+    crawled_pages: Optional[int] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    raw_genre: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the plan."""
+
+        payload: Dict[str, Any] = {
+            "name": self.name,
+            "url": self.url,
+            "stories": list(self.stories),
+        }
+        if self.total_pages is not None:
+            payload["total_pages"] = self.total_pages
+        if self.crawled_pages is not None:
+            payload["crawled_pages"] = self.crawled_pages
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        if self.raw_genre:
+            payload["raw_genre"] = dict(self.raw_genre)
+        return payload
+
+
+@dataclass(slots=True)
+class CrawlPlan:
+    """Container that holds the full crawl plan for a site."""
+
+    site_key: str
+    categories: List[CategoryCrawlPlan] = field(default_factory=list)
+
+    def add_category(self, category: CategoryCrawlPlan) -> None:
+        self.categories.append(category)
+
+    @property
+    def total_categories(self) -> int:
+        return len(self.categories)
+
+    def as_mapping(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Return a ``dict`` mapping category name to the list of stories."""
+
+        return {category.name: list(category.stories) for category in self.categories}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the full plan."""
+
+        return {
+            "site_key": self.site_key,
+            "total_categories": self.total_categories,
+            "categories": [category.to_dict() for category in self.categories],
+        }
+
+    def split_into_batches(self, batch_size: int) -> List[Dict[str, List[Dict[str, Any]]]]:
+        """Group categories into batches of ``batch_size`` for workers.
+
+        The function returns a list where each element is a mapping with the
+        ``Category -> Stories`` layout requested by the user.  Consumers can use
+        it to dispatch independent crawl jobs without recomputing discovery.
+        """
+
+        if batch_size <= 0:
+            raise ValueError("batch_size must be a positive integer")
+
+        batches: List[Dict[str, List[Dict[str, Any]]]] = []
+        for start in range(0, len(self.categories), batch_size):
+            chunk = self.categories[start : start + batch_size]
+            batches.append({category.name: list(category.stories) for category in chunk})
+        return batches
+
+
+async def build_category_plan(
+    adapter: BaseSiteAdapter,
+    raw_genre: Dict[str, Any],
+    site_key: str,
+    *,
+    position: Optional[int] = None,
+    total_genres: Optional[int] = None,
+    max_pages: Optional[int] = None,
+    extra_metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[CategoryCrawlPlan]:
+    """Create a :class:`CategoryCrawlPlan` for ``raw_genre``.
+
+    The helper mirrors the logic that previously lived inside
+    ``process_genre_item`` so that both the planning phase and the execution
+    phase can share the same retry semantics.
+    """
+
+    genre_name = _normalise_genre_name(raw_genre)
+    genre_url = _normalise_genre_url(raw_genre)
+    if not genre_name or not genre_url:
+        return None
+
+    retry_time = 0
+    # ``RETRY_GENRE_ROUND_LIMIT`` is optional in configuration.  Fallback to 5
+    # to preserve the previous behaviour.
+    max_retry = int(getattr(app_config, "RETRY_GENRE_ROUND_LIMIT", 5) or 5)
+    sleep_seconds = float(getattr(app_config, "RETRY_SLEEP_SECONDS", 5) or 5)
+
+    while True:
+        try:
+            (
+                stories,
+                total_pages,
+                crawled_pages,
+            ) = await adapter.get_all_stories_from_genre_with_page_check(
+                genre_name,
+                genre_url,
+                site_key=site_key,
+                max_pages=max_pages,
+            )
+            if not stories:
+                raise ValueError(
+                    f"Danh sách truyện rỗng cho genre {genre_name} ({genre_url})"
+                )
+
+            metrics_tracker.set_genre_story_total(site_key, genre_url, len(stories))
+
+            if (
+                total_pages
+                and crawled_pages is not None
+                and crawled_pages < total_pages
+            ):
+                logger.warning(
+                    "Thể loại %s chỉ crawl được %s/%s trang, sẽ retry lần %s...",
+                    genre_name,
+                    crawled_pages,
+                    total_pages,
+                    retry_time + 1,
+                )
+                retry_time += 1
+                if retry_time >= max_retry:
+                    logger.error(
+                        "Thể loại %s không crawl đủ số trang sau %s lần.",
+                        genre_name,
+                        max_retry,
+                    )
+                    log_failed_genre({"name": genre_name, "url": genre_url})
+                    metrics_tracker.genre_failed(
+                        site_key,
+                        genre_url,
+                        reason=f"incomplete_pages_{crawled_pages}_{total_pages}",
+                        genre_name=genre_name,
+                    )
+                    return None
+                await asyncio.sleep(min(sleep_seconds, 60.0))
+                continue
+
+            metadata: Dict[str, Any] = {}
+            if isinstance(raw_genre, dict):
+                metadata.update(
+                    {
+                        k: v
+                        for k, v in raw_genre.items()
+                        if k
+                        not in {
+                            "name",
+                            "title",
+                            "label",
+                            "category",
+                            "url",
+                            "link",
+                            "href",
+                        }
+                    }
+                )
+            if extra_metadata:
+                metadata.update(extra_metadata)
+            if position is not None:
+                metadata.setdefault("position", position)
+            if total_genres is not None:
+                metadata.setdefault("total_genres", total_genres)
+
+            return CategoryCrawlPlan(
+                name=genre_name,
+                url=genre_url,
+                stories=list(stories),
+                total_pages=total_pages,
+                crawled_pages=crawled_pages,
+                metadata=metadata,
+                raw_genre=dict(raw_genre),
+            )
+        except Exception as ex:  # pragma: no cover - defensive logging branch
+            logger.error(
+                "Lỗi khi crawl genre %s (%s): %s",
+                raw_genre.get("name", genre_name),
+                raw_genre.get("url", genre_url),
+                ex,
+            )
+            log_failed_genre({"name": genre_name, "url": genre_url})
+            metrics_tracker.genre_failed(
+                site_key,
+                genre_url or raw_genre.get("url", ""),
+                reason=str(ex),
+                genre_name=genre_name or raw_genre.get("name", ""),
+            )
+            return None
+
+
+async def build_crawl_plan(
+    adapter: BaseSiteAdapter,
+    *,
+    max_pages: Optional[int] = None,
+    extra_metadata: Optional[Dict[str, Any]] = None,
+    genres: Optional[Iterable[Dict[str, Any]]] = None,
+) -> CrawlPlan:
+    """Construct a :class:`CrawlPlan` for ``adapter``.
+
+    Parameters
+    ----------
+    adapter:
+        The site adapter responsible for discovery.
+    max_pages:
+        Optional safety limit passed to ``get_all_stories_from_genre`` to avoid
+        crawling beyond the configured number of pages.
+    extra_metadata:
+        Additional metadata merged into every ``CategoryCrawlPlan`` to simplify
+        downstream reporting.
+    """
+
+    site_key = getattr(adapter, "site_key", None) or adapter.get_site_key()
+    raw_genres: Iterable[Dict[str, Any]]
+    if genres is None:
+        raw_genres = await adapter.get_genres() or []
+    else:
+        raw_genres = list(genres)
+
+    plan = CrawlPlan(site_key=site_key)
+    raw_genres_list = list(raw_genres)
+    total_genres = len(raw_genres_list)
+
+    for index, raw_genre in enumerate(raw_genres_list, start=1):
+        category_plan = await build_category_plan(
+            adapter,
+            raw_genre,
+            site_key,
+            position=index,
+            total_genres=total_genres,
+            max_pages=max_pages,
+            extra_metadata=extra_metadata,
+        )
+        if category_plan:
+            plan.add_category(category_plan)
+
+    return plan
+

--- a/tests/test_crawl_planner.py
+++ b/tests/test_crawl_planner.py
@@ -1,0 +1,175 @@
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from adapters.base_site_adapter import BaseSiteAdapter
+from core.crawl_planner import (
+    CategoryCrawlPlan,
+    CrawlPlan,
+    build_category_plan,
+    build_crawl_plan,
+)
+
+
+class _StubAdapter(BaseSiteAdapter):
+    site_key = "stub"
+
+    def __init__(self) -> None:
+        self._captured_calls: List[Dict[str, Any]] = []
+
+    async def get_genres(self) -> List[Dict[str, str]]:
+        return [
+            {"name": "Tiên Hiệp", "url": "https://example.com/tien-hiep"},
+            {"name": "Kiếm Hiệp", "url": "https://example.com/kiem-hiep"},
+            {"name": "Bỏ Qua"},  # Missing URL should be ignored
+        ]
+
+    async def get_stories_in_genre(self, genre_url: str, page: int = 1):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    async def get_all_stories_from_genre(
+        self,
+        genre_name: str,
+        genre_url: str,
+        max_pages: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:  # pragma: no cover - delegated to *_with_page_check
+        return []
+
+    async def get_story_details(self, story_url: str, story_title: str):  # pragma: no cover - not needed
+        raise NotImplementedError
+
+    async def get_chapter_list(
+        self,
+        story_url: str,
+        story_title: str,
+        site_key: str,
+        max_pages: Optional[int] = None,
+        total_chapters: Optional[int] = None,
+    ):  # pragma: no cover - not needed
+        raise NotImplementedError
+
+    async def get_chapter_content(self, chapter_url: str, chapter_title: str, site_key: str):  # pragma: no cover - not needed
+        raise NotImplementedError
+
+    async def get_all_stories_from_genre_with_page_check(
+        self,
+        genre_name: str,
+        genre_url: str,
+        site_key: str,
+        max_pages: Optional[int] = None,
+    ):
+        self._captured_calls.append(
+            {
+                "genre_name": genre_name,
+                "genre_url": genre_url,
+                "site_key": site_key,
+                "max_pages": max_pages,
+            }
+        )
+        stories = [{"title": f"{genre_name} Story", "url": genre_url + "/story"}]
+        return stories, 3, 3
+
+
+@pytest.mark.asyncio
+async def test_category_plan_to_dict_roundtrip():
+    plan = CategoryCrawlPlan(
+        name="Tiên Hiệp",
+        url="https://example.com/tien-hiep",
+        stories=[{"title": "Story A"}],
+        total_pages=4,
+        crawled_pages=2,
+        metadata={"position": 1},
+        raw_genre={"name": "Tiên Hiệp", "url": "https://example.com/tien-hiep", "slug": "tien-hiep"},
+    )
+
+    payload = plan.to_dict()
+    assert payload["name"] == "Tiên Hiệp"
+    assert payload["url"].endswith("tien-hiep")
+    assert payload["total_pages"] == 4
+    assert payload["crawled_pages"] == 2
+    assert payload["stories"][0]["title"] == "Story A"
+    assert payload["metadata"]["position"] == 1
+    assert payload["raw_genre"]["slug"] == "tien-hiep"
+
+
+@pytest.mark.asyncio
+async def test_crawl_plan_generation_and_batches():
+    adapter = _StubAdapter()
+
+    selected_genres = [
+        {"name": "Tiên Hiệp", "url": "https://example.com/tien-hiep"},
+        {"name": "Kiếm Hiệp", "url": "https://example.com/kiem-hiep"},
+    ]
+    plan = await build_crawl_plan(
+        adapter,
+        genres=selected_genres,
+        max_pages=2,
+        extra_metadata={"source": "unit-test"},
+    )
+
+    assert isinstance(plan, CrawlPlan)
+    assert plan.site_key == "stub"
+    assert plan.total_categories == 2
+
+    mapping = plan.as_mapping()
+    assert set(mapping.keys()) == {"Tiên Hiệp", "Kiếm Hiệp"}
+    assert mapping["Tiên Hiệp"][0]["title"] == "Tiên Hiệp Story"
+
+    batches = plan.split_into_batches(batch_size=1)
+    assert len(batches) == 2
+    assert batches[0] == {"Tiên Hiệp": mapping["Tiên Hiệp"]}
+
+    as_dict = plan.to_dict()
+    assert as_dict["total_categories"] == 2
+    first_meta = as_dict["categories"][0]["metadata"]
+    assert first_meta["position"] == 1
+    assert first_meta["total_genres"] == 2
+    assert first_meta["source"] == "unit-test"
+    assert as_dict["categories"][0]["raw_genre"]["name"] == "Tiên Hiệp"
+
+    assert adapter._captured_calls == [
+        {
+            "genre_name": "Tiên Hiệp",
+            "genre_url": "https://example.com/tien-hiep",
+            "site_key": "stub",
+            "max_pages": 2,
+        },
+        {
+            "genre_name": "Kiếm Hiệp",
+            "genre_url": "https://example.com/kiem-hiep",
+            "site_key": "stub",
+            "max_pages": 2,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_category_plan_handles_metadata(monkeypatch):
+    adapter = _StubAdapter()
+
+    plan = await build_category_plan(
+        adapter,
+        {"name": "Tiên Hiệp", "url": "https://example.com/tien-hiep", "extra": 1},
+        "stub",
+        position=2,
+        total_genres=5,
+        max_pages=1,
+        extra_metadata={"batch": "demo"},
+    )
+
+    assert isinstance(plan, CategoryCrawlPlan)
+    assert plan.metadata["position"] == 2
+    assert plan.metadata["total_genres"] == 5
+    assert plan.metadata["batch"] == "demo"
+    assert plan.raw_genre["extra"] == 1
+
+
+def test_split_into_batches_rejects_invalid_size():
+    plan = CrawlPlan(site_key="stub")
+    with pytest.raises(ValueError):
+        plan.split_into_batches(0)
+


### PR DESCRIPTION
## Summary
- extend the crawl planner to build per-category plans with retry-aware discovery, raw metadata, and batch helpers
- refactor the main crawl flow to consume precomputed plans, persist category progress, and reuse prefetched story lists
- update unit tests to exercise the planner helpers and the revised run_crawler batching behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e13f32841883299d29d7816c4da40e