### PR TITLE
Implement streaming story crawl pipeline

### DIFF
--- a/adapters/base_site_adapter.py
+++ b/adapters/base_site_adapter.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import Any, Awaitable, Callable, ClassVar, Dict, List, Optional
 
 
 class BaseSiteAdapter(ABC):
@@ -44,7 +44,18 @@ class BaseSiteAdapter(ABC):
         pass
 
     @abstractmethod
-    async def get_all_stories_from_genre_with_page_check(self, genre_name, genre_url, site_key, max_pages=None):
+    async def get_all_stories_from_genre_with_page_check(
+        self,
+        genre_name,
+        genre_url,
+        site_key,
+        max_pages=None,
+        *,
+        page_callback: Optional[
+            Callable[[List[Dict[str, Any]], int, Optional[int]], Awaitable[None]]
+        ] = None,
+        collect: bool = True,
+    ):
         pass
 
     def get_chapters_per_page_hint(self) -> int:

--- a/tests/test_crawl_planner.py
+++ b/tests/test_crawl_planner.py
@@ -61,6 +61,9 @@ class _StubAdapter(BaseSiteAdapter):
         genre_url: str,
         site_key: str,
         max_pages: Optional[int] = None,
+        *,
+        page_callback=None,
+        collect: bool = True,
     ):
         self._captured_calls.append(
             {
@@ -71,7 +74,9 @@ class _StubAdapter(BaseSiteAdapter):
             }
         )
         stories = [{"title": f"{genre_name} Story", "url": genre_url + "/story"}]
-        return stories, 3, 3
+        if page_callback:
+            await page_callback(list(stories), 1, 3)
+        return (stories if collect else [], 3, 3)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace batch-based category crawling with a streaming queue that dispatches per-story jobs and updates registry-backed metrics incrementally
- extend adapter interfaces to support per-page callbacks without collecting all stories upfront
- adjust tests to cover the streaming workflow and updated adapter signatures

## Testing
- pytest tests/test_main.py::test_process_genre_item_retries_and_skips tests/test_workers.py::test_process_genre_item_batches

------
https://chatgpt.com/codex/tasks/task_e_68e156d4e4d0832993db32e76a587e31