### PR TITLE
Add crawl lifecycle logging and retry states

### DIFF
--- a/core/story_registry.py
+++ b/core/story_registry.py
@@ -20,6 +20,8 @@ class StoryCrawlStatus(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"
     COOLDOWN = "cooldown"
+    NEEDS_RETRY = "needs_retry"
+    PERMANENT_FAIL = "permanent_fail"
 
 
 @dataclass(frozen=True)

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -365,7 +365,7 @@ async def test_process_genre_item_batches(tmp_path, monkeypatch):
     monkeypatch.setattr("main.clear_specific_state_keys", AsyncMock())
 
     called = []
-    async def fake_process_story(session, story, g, folder, state, ad, sk):
+    async def fake_process_story(session, story, g, folder, state, ad, sk, **kwargs):
         called.append(story["title"])
         return True
     monkeypatch.setattr("main.process_story_item", fake_process_story)


### PR DESCRIPTION
## Summary
- propagate category and registry identifiers through the crawl pipeline so metrics can group events per {category, story}
- log start/success/failure/retry transitions from the multi-source crawler and persist the history in the dashboard snapshot
- add explicit `needs_retry`/`permanent_fail` states and update tests to cover the new lifecycle and event tracking helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e15ecafc8c8329938de7d2c014a548